### PR TITLE
Rework symbol table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+Rework symbol table for more accurate definitions.
+
 ## v1.6.3
 
 Fix crashes when file has grammar errors.

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -80,7 +80,7 @@ Go to definition:
 - [x] Add go to definition functionality; see https://tomassetti.me/integrating-code-completion-in-visual-studio-code/
 - [x] Invalidate cache of consumers when library stored
 - [x] Support additional ways of declaring variables (e.g. in REDUCTION lib)
-- [ ] Properly implement macro resolution
+- [ ] Properly implement macro resolution (see TODOs in corresponding unit test)
 - [ ] Improve performance by considering previous resolutions
 
 Support writing ProVerif:

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -80,6 +80,8 @@ Go to definition:
 - [x] Add go to definition functionality; see https://tomassetti.me/integrating-code-completion-in-visual-studio-code/
 - [x] Invalidate cache of consumers when library stored
 - [x] Support additional ways of declaring variables (e.g. in REDUCTION lib)
+- [ ] Properly implement macro resolution
+- [ ] Improve performance by considering previous resolutions
 
 Support writing ProVerif:
 - [x] Configure language

--- a/docs/kitchensink.pv
+++ b/docs/kitchensink.pv
@@ -29,7 +29,7 @@ channel public2.
 
 table Storage(key_t).
 
-letfun no_conversion(key: key_t) = let k' = convert(key) in new k2: bitstring; k2. 
+letfun no_conversion(key: key_t) = let k' = convert(key) in new k2: bitstring; get Storage(=key) in k2. 
 let publish(key: key_t or fail) = out(public, key). 
 
 set attacker = passive.

--- a/docs/kitchensink.pv
+++ b/docs/kitchensink.pv
@@ -29,7 +29,7 @@ channel public2.
 
 table Storage(key_t).
 
-letfun no_conversion(key: key_t) = let k' = convert(key) in k'. 
+letfun no_conversion(key: key_t) = let k' = convert(key) in new k2: bitstring; k2. 
 let publish(key: key_t or fail) = out(public, key). 
 
 set attacker = passive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,9 +450,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -539,15 +539,15 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.79",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.79.tgz",
-			"integrity": "sha512-Qd7jdLR5zmnIyMhfDrfPqN5tUCvreVpP3Qrf2oSM+F7SNzlb/MwHISGUkdFHtevfkPJ3iAGyeQI/jsbh9EStgQ==",
+			"version": "16.18.91",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.91.tgz",
+			"integrity": "sha512-h8Q4klc8xzc9kJKr7UYNtJde5TU2qEePVyH3WyzJaUC+3ptyc5kPQbWOIUcn8ZsG5+KSkq+P0py0kC0VqxgAXw==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -745,16 +745,15 @@
 			"dev": true
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.23.0.tgz",
-			"integrity": "sha512-Wf9yN8feZf4XmUW/erXyKQvCL577u72AQv4AI4Cwt5o5NyE49C5mpfw3pN78BJYYG3qnSIxwRo7JPvEurkQuNA==",
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.24.0.tgz",
+			"integrity": "sha512-p6CIXpH5HXDqmUkgFXvIKTjZpZxy/uDx4d/UsfhS9vQUun43KDNUbYeZocyAHgqcJlPEurgArHz9te1PPiqPyA==",
 			"dev": true,
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.9",
 				"commander": "^6.2.1",
-				"find-yarn-workspace-root": "^2.0.0",
 				"glob": "^7.0.6",
 				"hosted-git-info": "^4.0.2",
 				"jsonc-parser": "^3.2.0",
@@ -915,12 +914,15 @@
 			"optional": true
 		},
 		"node_modules/binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/bl": {
@@ -1004,15 +1006,16 @@
 			}
 		},
 		"node_modules/call-bind": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.6.tgz",
-			"integrity": "sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
 			"dev": true,
 			"dependencies": {
+				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.3",
-				"set-function-length": "^1.2.0"
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -1291,24 +1294,26 @@
 			"dev": true
 		},
 		"node_modules/define-data-property": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.2.tgz",
-			"integrity": "sha512-SRtsSqsDbgpJBbW3pABMCOt6rQyeM8s8RiyeSN8jYG8sYmt/kGJejbydttUsnDs1tadr19tvhT4ShwMyoqAm4g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dev": true,
 			"dependencies": {
+				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.2",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.1"
+				"gopd": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
 			"dev": true,
 			"optional": true,
 			"engines": {
@@ -1431,6 +1436,18 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-errors": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -1497,16 +1514,16 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.56.0",
-				"@humanwhocodes/config-array": "^0.11.13",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -1874,15 +1891,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/find-yarn-workspace-root": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-			"dev": true,
-			"dependencies": {
-				"micromatch": "^4.0.2"
-			}
-		},
 		"node_modules/flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -1907,15 +1915,15 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.5",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-			"integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2098,21 +2106,21 @@
 			}
 		},
 		"node_modules/has-property-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-			"integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"dev": true,
 			"dependencies": {
-				"get-intrinsic": "^1.2.2"
+				"es-define-property": "^1.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -2134,9 +2142,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -2825,9 +2833,9 @@
 			"dev": true
 		},
 		"node_modules/node-abi": {
-			"version": "3.54.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
-			"integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+			"integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -2901,9 +2909,9 @@
 			}
 		},
 		"node_modules/ovsx": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.8.3.tgz",
-			"integrity": "sha512-LG7wTzy4eYV/KolFeO4AwWPzQSARvCONzd5oHQlNvYOlji2r/zjbdK8pyObZN84uZlk6rQBWrJrAdJfh/SX0Hg==",
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.8.4.tgz",
+			"integrity": "sha512-RMtGSVNM4NWSF9uVWCUqaYiA7ID8Vqm/rSk2W37eYVrDLOI/3do2IRY7rQYkvJqb6sS6LAnALODBkD50tIM1kw==",
 			"dev": true,
 			"dependencies": {
 				"@vscode/vsce": "^2.19.0",
@@ -3061,9 +3069,9 @@
 			}
 		},
 		"node_modules/prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+			"integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -3117,12 +3125,12 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-			"integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
+			"integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
 			"dev": true,
 			"dependencies": {
-				"side-channel": "^1.0.4"
+				"side-channel": "^1.0.6"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -3342,17 +3350,17 @@
 			}
 		},
 		"node_modules/set-function-length": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-			"integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"dev": true,
 			"dependencies": {
-				"define-data-property": "^1.1.2",
+				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.3",
+				"get-intrinsic": "^1.2.4",
 				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.1"
+				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3380,12 +3388,12 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-			"integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.6",
+				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
 				"get-intrinsic": "^1.2.4",
 				"object-inspect": "^1.13.1"
@@ -3550,15 +3558,12 @@
 			"dev": true
 		},
 		"node_modules/tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
 			"dev": true,
-			"dependencies": {
-				"rimraf": "^3.0.0"
-			},
 			"engines": {
-				"node": ">=8.17.0"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -3652,9 +3657,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+			"integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/server/src/go_to_definition.ts
+++ b/server/src/go_to_definition.ts
@@ -4,8 +4,9 @@ import {getMatchingParseTree} from "./parseTree/get_matching_parse_tree";
 import {getRange} from "./parseTree/get_range";
 import {DefinitionLink} from "vscode-languageserver-protocol";
 import {ParseTree} from "antlr4ts/tree";
-import {ProverifSymbol} from "./tasks/create_symbol_table";
+import {DeclarationType, ProverifSymbol} from "./tasks/create_symbol_table";
 import {TerminalNode} from "antlr4ts/tree/TerminalNode";
+import {LibraryDependencyToken} from "./tasks/parse_library_dependencies";
 
 type Origin = { uri: TextDocumentIdentifier, match: TerminalNode };
 export type DefinitionSymbol = { uri: TextDocumentIdentifier, symbol: ProverifSymbol, origin: Origin }
@@ -26,22 +27,27 @@ export const getDefinitionSymbolFromPosition = async (identifier: TextDocumentId
 
 
 export const getDefinitionSymbolFromMatch = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface): Promise<DefinitionSymbol | undefined> => {
-    const definition = getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager, false);
-    if (definition) {
-        return definition;
-    }
-
-    return getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager, true);
+    return  getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager);
 };
 
-export const getDefinitionSymbolFromMatchMacroAware = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface, considerMacros: boolean): Promise<DefinitionSymbol | undefined> => {
+const getDefinitionSymbolFromMatchMacroAware = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface): Promise<DefinitionSymbol | undefined> => {
     const origin = {uri: parseResult.identifier, match: matchingParseTree};
 
-    const closestSymbol = parseResult.symbolTable.findClosestSymbol(matchingParseTree.text, matchingParseTree, considerMacros);
+    const closestSymbol = parseResult.symbolTable.findClosestSymbol(matchingParseTree.text, matchingParseTree);
     if (closestSymbol) {
+        if (closestSymbol.declaration === DeclarationType.ExpandParameter) {
+            // TODO: break the cycle
+            const originSymbol = await getDefinitionSymbolFromMatch(parseResult, closestSymbol.node, documentManager);
+            if (originSymbol) {
+                return originSymbol;
+            }
+        }
+
         return {uri: parseResult.identifier, symbol: closestSymbol, origin};
     }
 
+    let currentClosestSymbol: ProverifSymbol|undefined;
+    let currentClosestSymbolDependency: LibraryDependencyToken|undefined;
     for (let i = 0; i < parseResult.dependencyTokens.length; i++) {
         const dependency = parseResult.dependencyTokens[i];
         if (!dependency.exists) {
@@ -53,12 +59,23 @@ export const getDefinitionSymbolFromMatchMacroAware = async (parseResult: ParseR
             continue;
         }
 
-        const closestSymbol = dependencyParseResult.symbolTable.findClosestSymbol(matchingParseTree.text, undefined, considerMacros);
+        const closestSymbol = dependencyParseResult.symbolTable.findClosestSymbol(matchingParseTree.text, undefined);
         if (!closestSymbol) {
             continue;
         }
 
-        return {uri: dependency, symbol: closestSymbol, origin};
+        currentClosestSymbol = closestSymbol;
+        currentClosestSymbolDependency = dependency;
+        if (closestSymbol.declaration === DeclarationType.ExpandParameter) {
+            // TODO: check in library first for previous declaration, before going to another library
+            continue;
+        }
+
+        break;
+    }
+
+    if (currentClosestSymbol && currentClosestSymbolDependency) {
+        return {uri: currentClosestSymbolDependency, symbol: currentClosestSymbol, origin}
     }
 
     return undefined;

--- a/server/src/go_to_definition.ts
+++ b/server/src/go_to_definition.ts
@@ -26,9 +26,18 @@ export const getDefinitionSymbolFromPosition = async (identifier: TextDocumentId
 
 
 export const getDefinitionSymbolFromMatch = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface): Promise<DefinitionSymbol | undefined> => {
+    const definition = getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager, false);
+    if (definition) {
+        return definition
+    }
+
+    return getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager, true)
+};
+
+export const getDefinitionSymbolFromMatchMacroAware = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface, considerMacros: boolean): Promise<DefinitionSymbol | undefined> => {
     const origin = {uri: parseResult.identifier, match: matchingParseTree};
 
-    const closestSymbol = parseResult.symbolTable.findClosestSymbol(matchingParseTree.text, matchingParseTree);
+    const closestSymbol = parseResult.symbolTable.findClosestSymbol(matchingParseTree.text, matchingParseTree, considerMacros);
     if (closestSymbol) {
         return {uri: parseResult.identifier, symbol: closestSymbol, origin};
     }
@@ -44,7 +53,7 @@ export const getDefinitionSymbolFromMatch = async (parseResult: ParseResult, mat
             continue;
         }
 
-        const closestSymbol = dependencyParseResult.symbolTable.findClosestSymbol(matchingParseTree.text);
+        const closestSymbol = dependencyParseResult.symbolTable.findClosestSymbol(matchingParseTree.text, undefined, considerMacros);
         if (!closestSymbol) {
             continue;
         }

--- a/server/src/go_to_definition.ts
+++ b/server/src/go_to_definition.ts
@@ -28,10 +28,10 @@ export const getDefinitionSymbolFromPosition = async (identifier: TextDocumentId
 export const getDefinitionSymbolFromMatch = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface): Promise<DefinitionSymbol | undefined> => {
     const definition = getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager, false);
     if (definition) {
-        return definition
+        return definition;
     }
 
-    return getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager, true)
+    return getDefinitionSymbolFromMatchMacroAware(parseResult, matchingParseTree, documentManager, true);
 };
 
 export const getDefinitionSymbolFromMatchMacroAware = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface, considerMacros: boolean): Promise<DefinitionSymbol | undefined> => {

--- a/server/src/go_to_definition.ts
+++ b/server/src/go_to_definition.ts
@@ -28,7 +28,7 @@ export const getDefinitionSymbolFromPosition = async (identifier: TextDocumentId
 export const getDefinitionSymbolFromMatch = async (parseResult: ParseResult, matchingParseTree: TerminalNode, documentManager: DocumentManagerInterface): Promise<DefinitionSymbol | undefined> => {
     const origin = {uri: parseResult.identifier, match: matchingParseTree};
 
-    const closestSymbol = parseResult.symbolTable.findClosestSymbol(matchingParseTree);
+    const closestSymbol = parseResult.symbolTable.findClosestSymbol(matchingParseTree.text, matchingParseTree);
     if (closestSymbol) {
         return {uri: parseResult.identifier, symbol: closestSymbol, origin};
     }
@@ -44,7 +44,7 @@ export const getDefinitionSymbolFromMatch = async (parseResult: ParseResult, mat
             continue;
         }
 
-        const closestSymbol = dependencyParseResult.symbolTable.findClosestSymbol(matchingParseTree);
+        const closestSymbol = dependencyParseResult.symbolTable.findClosestSymbol(matchingParseTree.text);
         if (!closestSymbol) {
             continue;
         }

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -98,6 +98,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
                 const parameters = collectTypeidseq(() => ctx.typeidseq());
                 const identifier = collectIdentifier(() => ctx.IDENT());
                 this.registerTerminalWithParameters(identifier, DeclarationType.Fun, parameters, getType(() => ctx.typeid()));
+                this.withContext(ctx, () => this.visitInner(() => ctx.treducmayfail()));
             } else if (ctx.EVENT() || ctx.PREDICATE() || ctx.TABLE()) {
                 const identifier = collectIdentifier(() => ctx.IDENT());
                 const declarationType =
@@ -225,7 +226,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
                 this.registerTerminals(identifiers, DeclarationType.Variable);
             }
 
-            return this.visit(ctx);
+            return this.visitChildren(ctx);
         });
     };
 

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -409,28 +409,28 @@ export class ProverifSymbolTable {
         this.publicContext = publicContext;
     }
 
-    public findClosestSymbol(text: string, context: ParseTree|undefined, considerMacros: boolean): ProverifSymbol | undefined {
-        return this.findClosestSymbolInternal(text, context ?? this.publicContext, considerMacros);
+    public findClosestSymbol(text: string, context: ParseTree|undefined): ProverifSymbol | undefined {
+        return this.findClosestSymbolInternal(text, context ?? this.publicContext);
     }
 
     public getSymbols(): ProverifSymbol[] {
         return this.symbols;
     }
 
-    private findClosestSymbolInternal(name: string, context: ParseTree|undefined, considerMacros: boolean): ProverifSymbol | undefined {
+    private findClosestSymbolInternal(name: string, context: ParseTree|undefined): ProverifSymbol | undefined {
         if (!context) {
             return undefined;
         }
 
         const symbolsOfContext = this.symbols.filter(symbol => symbol.context === context);
         const matchingSymbol = symbolsOfContext.find(symbol => symbol.node.text === name);
-        if (matchingSymbol && (considerMacros || matchingSymbol.declaration !== DeclarationType.ExpandParameter)) {
+        if (matchingSymbol) {
             return matchingSymbol;
         }
 
         // if in tprocess, check whether defined in library
         if (context instanceof TprocessContext && context.parent instanceof AllContext) {
-            return this.findClosestSymbolInternal(name, this.publicContext, considerMacros);
+            return this.findClosestSymbolInternal(name, this.publicContext);
         }
 
         // if in OTHERWISE, then jump directly to the real parent, not the previous clauses
@@ -440,10 +440,10 @@ export class ProverifSymbolTable {
                 realParent = realParent.parent;
             }
 
-            return this.findClosestSymbolInternal(name, realParent, considerMacros);
+            return this.findClosestSymbolInternal(name, realParent);
         }
 
-        return this.findClosestSymbolInternal(name, context.parent, considerMacros);
+        return this.findClosestSymbolInternal(name, context.parent);
     }
 }
 

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -253,7 +253,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
     public visitPterm = (ctx: PtermContext) => {
         return this.withContext(ctx, () => {
             this.collectProcessStyleTerms(ctx, false);
-            
+
             this.visitInners(() => ctx.pterm());
             this.visitInner(() => ctx.optelseterm());
 

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -78,6 +78,8 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
     }
 
     public visitLib = (ctx: LibContext) => {
+        this.symbolTable.setPublicContext(ctx);
+
         return this.withContext(ctx, () => {
             const libs = ctx.lib();
 
@@ -378,13 +380,18 @@ export type ProverifSymbol = {
 
 export class ProverifSymbolTable {
     private symbols: ProverifSymbol[] = [];
+    private publicContext: LibContext|undefined;
 
     public addSymbol(symbol: ProverifSymbol) {
         this.symbols.push(symbol);
     }
 
-    public findClosestSymbol(node: ParseTree): ProverifSymbol | undefined {
-        return this.findClosestSymbolInternal(node.text, node);
+    public setPublicContext(publicContext: LibContext) {
+        this.publicContext = publicContext;
+    }
+
+    public findClosestSymbol(text: string, context?: ParseTree): ProverifSymbol | undefined {
+        return this.findClosestSymbolInternal(text, context ?? this.publicContext);
     }
 
     public getSymbols(): ProverifSymbol[] {

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -416,8 +416,19 @@ export class ProverifSymbolTable {
             return matchingSymbol;
         }
 
+        // if in tprocess, check whether defined in library
         if (context instanceof TprocessContext && context.parent instanceof AllContext) {
             return this.findClosestSymbolInternal(name, this.publicContext);
+        }
+
+        // if in OTHERWISE, then jump directly to the real parent, not the previous clauses
+        if (context instanceof TreducotherwiseContext) {
+            let realParent = context.parent
+            while (realParent instanceof TreducotherwiseContext || realParent instanceof TreducmayfailContext) {
+                realParent = realParent.parent
+            }
+
+            return this.findClosestSymbolInternal(name, realParent);
         }
 
         return this.findClosestSymbolInternal(name, context.parent);

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -126,7 +126,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
             } else if (ctx.QUERY()) {
                 this.registerNevartypeParameters(() => ctx.nevartype());
                 this.visitInner(() => ctx.tqueryseq());
-            } else if (ctx.NONINTERF() || ctx.NOT() || ctx.lemma()) {
+            } else if (ctx.NONINTERF()) {
                 this.registerNevartypeParameters(() => ctx.nevartype());
                 this.visitInner(() => ctx.niseq());
             } else if (ctx.NOT()) {
@@ -435,9 +435,9 @@ export class ProverifSymbolTable {
 
         // if in OTHERWISE, then jump directly to the real parent, not the previous clauses
         if (context instanceof TreducotherwiseContext) {
-            let realParent = context.parent
+            let realParent = context.parent;
             while (realParent instanceof TreducotherwiseContext || realParent instanceof TreducmayfailContext) {
-                realParent = realParent.parent
+                realParent = realParent.parent;
             }
 
             return this.findClosestSymbolInternal(name, realParent, considerMacros);

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -139,6 +139,8 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
                 const typedTerminals = collectNemayfailvartypeseq(() => ctx.nemayfailvartypeseq());
                 this.registerTypedTerminals(typedTerminals, DeclarationType.Parameter);
                 this.visitInner(() => ctx.term());
+            }   else if (ctx.CLAUSES()) {
+                this.visitInner(() => ctx.tclauses());
             } else if (ctx.DEFINE()) {
                 const identifier = collectIdentifier(() => ctx.IDENT());
                 const declarationType = DeclarationType.Define;

--- a/server/src/tasks/create_symbol_table.ts
+++ b/server/src/tasks/create_symbol_table.ts
@@ -145,22 +145,17 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
 
                 this.withContext(ctx, () => {
                     this.registerTerminals(parameters, DeclarationType.DefineParameter);
-                    return libs.length > 0 ? this.visitChildren(libs[0]) : this.defaultResult();
+                    return libs.length > 0 ? this.visit(libs[0]) : this.defaultResult();
                 });
 
-                return libs.length > 1 ? this.visitChildren(libs[1]) : this.defaultResult();
+                return libs.length > 1 ? this.visit(libs[1]) : this.defaultResult();
             } else if (ctx.EXPAND()) {
                 const parameters = collectTypeidseq(() => ctx.typeidseq());
                 this.registerTerminals(parameters, DeclarationType.ExpandParameter);
             }
 
-            return libs.length > 0 ? this.visitChildren(libs[0]) : this.defaultResult();
+            return libs.length > 0 ? this.visit(libs[0]) : this.defaultResult();
         });
-    };
-
-    private visitInner = (getInner: () => ParserRuleContext | undefined) => {
-        const inner = getInner();
-        return inner ? this.visitChildren(inner) : this.defaultResult();
     };
 
     public visitTclauses = (ctx: TclausesContext) => {
@@ -168,7 +163,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
             const typedTerminals = collectForallmayfailvartype(() => ctx.forallmayfailvartype());
             this.registerTypedTerminals(typedTerminals, DeclarationType.Parameter);
 
-            return this.visitChildren(ctx.tclause());
+            return this.visit(ctx.tclause());
         });
 
         return this.visitInner(() => ctx.tclauses());
@@ -187,7 +182,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
             const typedTerminals = collectForallmayfailvartype(() => ctx.forallmayfailvartype());
             this.registerTypedTerminals(typedTerminals, DeclarationType.Parameter);
 
-            return this.visitChildren(ctx.extended_equation());
+            return this.visit(ctx.extended_equation());
         });
 
         return this.visitInner(() => ctx.treducotherwise())
@@ -210,7 +205,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
             const typedTerminals = collectForallvartype(() => ctx.forallvartype());
             this.registerTypedTerminals(typedTerminals, DeclarationType.Parameter);
 
-            return this.visitChildren(ctx.extended_equation());
+            return this.visit(ctx.extended_equation());
         });
     };
 
@@ -229,7 +224,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
                 this.registerTerminals(identifiers, DeclarationType.Variable);
             }
 
-            return this.visitChildren(ctx);
+            return this.visit(ctx);
         });
     };
 
@@ -241,14 +236,14 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
             }
 
             this.collectProcessStyleTerms(ctx, true);
-            return this.visitChildren(ctx);
+            return this.visitInners(() => ctx.tprocess());
         });
     };
 
     public visitPterm = (ctx: PtermContext) => {
         return this.withContext(ctx, () => {
             this.collectProcessStyleTerms(ctx, false);
-            return this.visitChildren(ctx);
+            return this.visitInners(() => ctx.pterm());
         });
     };
 
@@ -281,7 +276,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
                 this.registerTerminals(identifiers, DeclarationType.Variable);
             }
 
-            return this.visitChildren(ctx);
+            return this.visitInners(() => ctx.gterm());
         });
     };
 
@@ -292,7 +287,7 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
                 this.registerTerminals(identifiers, DeclarationType.Variable);
             }
 
-            return this.visitChildren(ctx);
+            return this.visitInners(() => ctx.gformat());
         });
     };
 
@@ -363,6 +358,16 @@ class SymbolTableVisitor extends AbstractParseTreeVisitor<ProverifSymbolTable> i
             this.context = previous;
         }
     }
+
+    private visitInner = (getInner: () => ParserRuleContext | undefined) => {
+        const inner = getInner();
+        return inner ? this.visit(inner) : this.defaultResult();
+    };
+
+    private visitInners = (getInner: () => ParserRuleContext[]) => {
+        getInner().forEach(inner => this.visit(inner));
+        return this.defaultResult();
+    };
 }
 
 export type ProverifSymbolParameter = {

--- a/server/src/tasks/ident_collectors.ts
+++ b/server/src/tasks/ident_collectors.ts
@@ -230,7 +230,7 @@ export const collectIdentifier = (getIdentifer: () => TerminalNode | undefined):
 
 export const collectSingleIdentifiers = (getIdentifer: () => TerminalNode | undefined): TerminalNode[] => {
     const identifier = tryGetTerminal(getIdentifer);
-    return [identifier].filter(nonNullable)
+    return [identifier].filter(nonNullable);
 };
 
 export const collectIdentifiers = (getIdentifer: () => TerminalNode[]): TerminalNode[] => {

--- a/server/src/tasks/ident_collectors.ts
+++ b/server/src/tasks/ident_collectors.ts
@@ -228,6 +228,11 @@ export const collectIdentifier = (getIdentifer: () => TerminalNode | undefined):
     return tryGetTerminal(getIdentifer);
 };
 
+export const collectSingleIdentifiers = (getIdentifer: () => TerminalNode | undefined): TerminalNode[] => {
+    const identifier = tryGetTerminal(getIdentifer);
+    return [identifier].filter(nonNullable)
+};
+
 export const collectIdentifiers = (getIdentifer: () => TerminalNode[]): TerminalNode[] => {
     return tryGetTerminals(getIdentifer) ?? [];
 };

--- a/server/tests/go_to_definition.test.ts
+++ b/server/tests/go_to_definition.test.ts
@@ -127,6 +127,14 @@ process System`;
         await assertSingleFileNavigation(code, click, target, 5);
     });
 
+    it("consider reduc", async () => {
+        const code = `fun redu(bitstring): bitstring\nreduc forall entry: bitstring;\nredu(entry) = entry.\nprocess 0`;
+        const click = {line: 2, character: 6};
+        const target = {line: 1, character: 13};
+
+        await assertSingleFileNavigation(code, click, target, 5);
+    });
+
     it("checks in dependencies if not found in main", async () => {
         const dependencyUri = 'dependency.pvl';
         const dependencyCode = `channel c.`;

--- a/server/tests/go_to_definition.test.ts
+++ b/server/tests/go_to_definition.test.ts
@@ -6,7 +6,12 @@ import {DefinitionLink} from "vscode-languageserver-protocol";
 import {MockDocumentManager} from "./mocks/mock_document_manager";
 
 describe('go to definition', function () {
-    const assertDefinitionPointsToTarget = (definitionLink: DefinitionLink | undefined, targetUri: string, target: Position, targetCharacterLength: number, source: Position) => {
+    const assertDefinitionPointsToTarget = (definitionLink: DefinitionLink | undefined, targetUri: string, target: Position|undefined, targetCharacterLength: number, source: Position) => {
+        if (!target) {
+            assert.isUndefined(definitionLink)
+            return;
+        }
+
         assert.isDefined(definitionLink);
         if (!definitionLink) {
             return;
@@ -28,7 +33,7 @@ describe('go to definition', function () {
         assert.isTrue(definitionLink.originSelectionRange.start.character <= source.character && source.character <= definitionLink.originSelectionRange.end.character);
     };
 
-    const assertSingleFileNavigation = async (code: string, click: Position, target: Position, targetCharacterLength: number) => {
+    const assertSingleFileNavigation = async (code: string, click: Position, target: Position|undefined, targetCharacterLength: number) => {
         const uri = 'main.pv';
 
         const documentManager = new MockDocumentManager();
@@ -133,6 +138,13 @@ process System`;
         const target = {line: 1, character: 13};
 
         await assertSingleFileNavigation(code, click, target, 5);
+    });
+
+    it("ignore otherwise clauses in reduc", async () => {
+        const code = `fun redu(bitstring): bitstring\nreduc forall entry:bitstring;redu(entry) = entry\notherwise forall entry2: bitstring;\nredu(entry) = entry.\nprocess 0`;
+        const click = {line: 3, character: 6};
+
+        await assertSingleFileNavigation(code, click, undefined, 5);
     });
 
     it("checks in dependencies if not found in main", async () => {

--- a/server/tests/go_to_definition.test.ts
+++ b/server/tests/go_to_definition.test.ts
@@ -99,13 +99,44 @@ def My(ProcImplementation,SystemInterface) {
 expand My(Proc, System).
 process System`;
 
-        const click = {line: 2, character: 28};
+        // ProcImplementation defined outside, hence this is the real definition
+        const click = {line: 1, character: 7};
         const target = {line: 1, character: 7};
-        await assertSingleFileNavigation(code, click, target, 18);
+        await assertSingleFileNavigation(code, click, target, 'ProcImplementation'.length);
 
-        const click2 = {line: 5, character: 9};
-        const target2 = {line: 4, character: 16};
-        await assertSingleFileNavigation(code, click2, target2, 6);
+        /* TODO implement
+        // SystemInterface defined inside macro
+        const click1 = {line: 1, character: 25};
+        const target1 = {line: 2, character: 12};
+        await assertSingleFileNavigation(code, click1, target1, 'SystemInterface'.length);
+        */
+
+        // SystemInterface defined inside macro
+        const click2 = {line: 2, character: 8};
+        const target2 = {line: 2, character: 8};
+        await assertSingleFileNavigation(code, click2, target2, 'SystemInterface'.length);
+
+        // ProcImplementation defined outside, hence definition inside macro signature
+        const click3 = {line: 2, character: 30};
+        const target3 = {line: 1, character: 7};
+        await assertSingleFileNavigation(code, click3, target3, 'ProcImplementation'.length);
+
+        // Proc defined at start
+        const click4 = {line: 4, character: 10};
+        const target4 = {line: 0, character: 4};
+        await assertSingleFileNavigation(code, click4, target4, 'Proc'.length);
+
+        /* TODO implement
+        // System defined by macro, hence navigate to macro signature
+        const click5 = {line: 4, character: 18};
+        const target5 = {line: 1, character: 23};
+        await assertSingleFileNavigation(code, click5, target5, 'Proc'.length);
+         */
+
+        // System defined by macro
+        const click6 = {line: 5, character: 9};
+        const target6 = {line: 4, character: 16};
+        await assertSingleFileNavigation(code, click6, target6, 'System'.length);
     });
 
     it("consider query variables", async () => {

--- a/server/tests/go_to_definition.test.ts
+++ b/server/tests/go_to_definition.test.ts
@@ -147,6 +147,14 @@ process System`;
         await assertSingleFileNavigation(code, click, undefined, 5);
     });
 
+    it("consider clauses", async () => {
+        const code = `pred p1.\nclauses forall entry: bitstring;\np1(entry).\nprocess 0`;
+        const click = {line: 2, character: 4};
+        const target = {line: 1, character: 15};
+
+        await assertSingleFileNavigation(code, click, target, 5);
+    });
+
     it("checks in dependencies if not found in main", async () => {
         const dependencyUri = 'dependency.pvl';
         const dependencyCode = `channel c.`;


### PR DESCRIPTION
The current symbol table does not collect all symbols. Notably, new declarations are not supported everywhere. Further, the symbol table treats lib statements as global context (hence not one-after-the-other, but all on the same level). This causes some invalid navigations (e.g. navigating to quantifier of different clause). Lastly, the behavior of macros is not clearly defined, and should be thought through. 

This PR approaches this in the following way:
- [x] Implement statements which define a variable directly (rather than in their parent rule)
- [x] Correctly track scope of the lib (and any other statement)
- [x] Define and implement clear macro behaviour